### PR TITLE
format using RFC3339

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -47,7 +47,7 @@ var TimestampGraphqlType = gql.NewObject(gql.ObjectConfig{
 		"ISOString": &gql.Field{
 			Type: gql.String,
 			Resolve: func(p gql.ResolveParams) (interface{}, error) {
-				return time.Unix(p.Source.(*timestamppb.Timestamp).Seconds, 0).Format("2006-01-02T15:04:05"), nil
+				return time.Unix(p.Source.(*timestamppb.Timestamp).Seconds, 0).Format(time.RFC3339), nil
 			},
 		},
 		"unix": &gql.Field{


### PR DESCRIPTION
Problem because output being formatted using `2006-01-02T15:04:05` but input being parsed using `time.RFC3339`

https://play.golang.org/p/-JT19H2R6h_Y

RFC3339 technically isn't the same as ISO8601: https://ijmacd.github.io/rfc3339-iso8601/
But formatting as `time.RFC3339` formats in a way that is also ISO8601