### PR TITLE
feat(dataloaders/template): Replace DNS host with SERVICE_HOST env var if present

### DIFF
--- a/generation/dataloaders/main.go
+++ b/generation/dataloaders/main.go
@@ -3,13 +3,14 @@ package dataloaders
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/iancoleman/strcase"
 	"github.com/kitt-technology/protoc-gen-graphql/generation/types"
 	"github.com/kitt-technology/protoc-gen-graphql/generation/util"
 	"github.com/kitt-technology/protoc-gen-graphql/graphql"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
-	"strings"
 )
 
 type Message struct {

--- a/generation/dataloaders/template.go
+++ b/generation/dataloaders/template.go
@@ -7,8 +7,13 @@ const msgTpl = `
 var {{ .Descriptor.Name }}ClientInstance {{ .Descriptor.Name }}Client
 
 func init() {
+	host := "{{ .Dns }}"
+	envHost := os.Getenv("SERVICE_HOST")
+	if envHost != "" {
+		host = envHost
+	}
 	fieldInits = append(fieldInits, func(opts ...grpc.DialOption) {
-		{{ .Descriptor.Name }}ClientInstance = New{{ .Descriptor.Name }}Client(pg.GrpcConnection("{{ .Dns }}", opts...))
+		{{ .Descriptor.Name }}ClientInstance = New{{ .Descriptor.Name }}Client(pg.GrpcConnection(host, opts...))
 	})
 	
 	{{- range $method := .Methods }}


### PR DESCRIPTION
Chosen to do this within the template itself, as otherwise it would only check for the env var on generation, whereas we want it to check on runtime/instantiation of the client