### PR TITLE
feat(dataloaders/template): Fetch host env var from dynamic string based on service name

### DIFF
--- a/generation/dataloaders/template.go
+++ b/generation/dataloaders/template.go
@@ -8,7 +8,7 @@ var {{ .Descriptor.Name }}ClientInstance {{ .Descriptor.Name }}Client
 
 func init() {
 	host := "{{ .Dns }}"
-	envHost := os.Getenv("SERVICE_HOST")
+	envHost := os.Getenv(fmt.Sprintf("%s_HOST", strings.ToUpper({{ $.ServiceName }})))
 	if envHost != "" {
 		host = envHost
 	}


### PR DESCRIPTION
Reason for this change is that I mistakenly thought that each service was responsible for setting up their service client, when in fact it's in `go-graphql`, so each service will need their own host env var. 

The idea here is that on `kitt deps` it will use the template to try and fetch an env var like `COMPANYSVC_HOST`, which dynamically changes based on the Service.Name variable